### PR TITLE
Remove floating point math

### DIFF
--- a/CapacitiveSensor.cpp
+++ b/CapacitiveSensor.cpp
@@ -27,9 +27,9 @@ CapacitiveSensor::CapacitiveSensor(uint8_t sendPin, uint8_t receivePin)
 	// initialize this instance's variables
 	// Serial.begin(9600);		// for debugging
 	error = 1;
-	loopTimingFactor = 310;		// determined empirically -  a hack
+	loopTimingFactor = 310l;		// determined empirically -  a hack
 
-	CS_Timeout_Millis = (2000 * (float)loopTimingFactor * (float)F_CPU) / 16000000;
+	CS_Timeout_Millis = (2000l * loopTimingFactor * F_CPU) / 16000000l;
 	CS_AutocaL_Millis = 20000;
 
 	// Serial.print("timwOut =  ");
@@ -74,7 +74,7 @@ long CapacitiveSensor::capacitiveSensor(uint8_t samples)
 		// only calibrate if time is greater than CS_AutocaL_Millis and total is less than 10% of baseline
 		// this is an attempt to keep from calibrating when the sensor is seeing a "touched" signal
 
-		if ( (millis() - lastCal > CS_AutocaL_Millis) && abs(total  - leastTotal) < (int)(.10 * (float)leastTotal) ) {
+		if ( (millis() - lastCal > CS_AutocaL_Millis) && abs(total  - leastTotal) < (leastTotal / 10) ) {
 
 			// Serial.println();               // debugging
 			// Serial.println("auto-calibrate");
@@ -127,8 +127,8 @@ void CapacitiveSensor::set_CS_AutocaL_Millis(unsigned long autoCal_millis){
 	CS_AutocaL_Millis = autoCal_millis;
 }
 
-void CapacitiveSensor::set_CS_Timeout_Millis(unsigned long timeout_millis){
-	CS_Timeout_Millis = (timeout_millis * (float)loopTimingFactor * (float)F_CPU) / 16000000;  // floats to deal with large numbers
+void CapacitiveSensor::set_CS_Timeout_Millis(long timeout_millis){
+	CS_Timeout_Millis = (timeout_millis * loopTimingFactor * F_CPU) / 16000000l;
 }
 
 // Private Methods /////////////////////////////////////////////////////////////

--- a/CapacitiveSensor.h
+++ b/CapacitiveSensor.h
@@ -81,7 +81,7 @@ class CapacitiveSensor
 	CapacitiveSensor(uint8_t sendPin, uint8_t receivePin);
 	long capacitiveSensorRaw(uint8_t samples);
 	long capacitiveSensor(uint8_t samples);
-	void set_CS_Timeout_Millis(unsigned long timeout_millis);
+	void set_CS_Timeout_Millis(long timeout_millis);
 	void reset_CS_AutoCal();
 	void set_CS_AutocaL_Millis(unsigned long autoCal_millis);
   // library-accessible "private" interface
@@ -89,7 +89,7 @@ class CapacitiveSensor
   // variables
 	int error;
 	unsigned long  leastTotal;
-	unsigned int   loopTimingFactor;
+	long   loopTimingFactor;
 	unsigned long  CS_Timeout_Millis;
 	unsigned long  CS_AutocaL_Millis;
 	unsigned long  lastCal;


### PR DESCRIPTION
The library used floats for things like calculating delays.
These were completely unnecessary and inflated resulting sketch sizes by around 500 bytes.
This may not be much on large-ish Arduinos like the Uno, but when compiling for devices like a Digispark (or directly for the ATTiny family of chips), these bytes can make all the difference.

Also, I think on Arduinos one should never use floating point math when ints or longs can do the job just fine...